### PR TITLE
fix: specify an api-version.

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ main: it.frafol.cleanping.bukkit.CleanPing
 authors: [ frafol ]
 folia-supported: true
 description: "Adds /ping command to check your and player's ping."
+api-version: 1.13
 commands:
   cleanping:
     description: Show your ping


### PR DESCRIPTION
 Console error: `Legacy plugin CleanPing v1.3 does not specify an api-version.`