### PR TITLE
Fix Bukkit Tab Completion

### DIFF
--- a/src/main/java/it/frafol/cleanping/bukkit/CleanPing.java
+++ b/src/main/java/it/frafol/cleanping/bukkit/CleanPing.java
@@ -13,12 +13,8 @@ import lombok.SneakyThrows;
 import net.byteflux.libby.BukkitLibraryManager;
 import net.byteflux.libby.Library;
 import net.byteflux.libby.relocation.Relocation;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.jetbrains.annotations.NotNull;
 import org.simpleyaml.configuration.file.YamlFile;
 
 import java.io.File;
@@ -30,11 +26,9 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
-public class CleanPing extends JavaPlugin implements TabExecutor {
+public class CleanPing extends JavaPlugin {
 
 	private TextFile configTextFile;
 	private TextFile messagesTextFile;
@@ -125,9 +119,7 @@ public class CleanPing extends JavaPlugin implements TabExecutor {
 
 			getLogger().info("Loading commands for legacy versions...");
 			Objects.requireNonNull(getCommand("ping")).setExecutor(new it.frafol.cleanping.bukkit.commands.legacy.PingCommand(this));
-			Objects.requireNonNull(getCommand("ping")).setTabCompleter(this);
 			Objects.requireNonNull(getCommand("cleanping")).setExecutor(new it.frafol.cleanping.bukkit.commands.legacy.PingCommand(this));
-			Objects.requireNonNull(getCommand("cleanping")).setTabCompleter(this);
 			Objects.requireNonNull(getCommand("pingreload")).setExecutor(new it.frafol.cleanping.bukkit.commands.legacy.ReloadCommand(this));
 			Objects.requireNonNull(getCommand("cleanpingreload")).setExecutor(new it.frafol.cleanping.bukkit.commands.legacy.ReloadCommand(this));
 
@@ -135,9 +127,7 @@ public class CleanPing extends JavaPlugin implements TabExecutor {
 
 			getLogger().info("Loading commands...");
 			Objects.requireNonNull(getCommand("ping")).setExecutor(new PingCommand(this));
-			Objects.requireNonNull(getCommand("ping")).setTabCompleter(this);
 			Objects.requireNonNull(getCommand("cleanping")).setExecutor(new PingCommand(this));
-			Objects.requireNonNull(getCommand("cleanping")).setTabCompleter(this);
 			Objects.requireNonNull(getCommand("pingreload")).setExecutor(new ReloadCommand(this));
 			Objects.requireNonNull(getCommand("cleanpingreload")).setExecutor(new ReloadCommand(this));
 
@@ -263,21 +253,5 @@ public class CleanPing extends JavaPlugin implements TabExecutor {
 		instance = null;
 
 		getLogger().info("Plugin successfully disabled!");
-	}
-
-	@Override
-	public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, String[] args) {
-
-		if (args.length != 1) {
-			return null;
-		}
-
-		String partialName = args[0].toLowerCase();
-
-		return getServer().getOnlinePlayers().stream()
-				.map(Player::getName)
-				.filter(name -> name.toLowerCase().startsWith(partialName))
-				.collect(Collectors.toList());
-
 	}
 }

--- a/src/main/java/it/frafol/cleanping/bukkit/commands/utils/TabComplete.java
+++ b/src/main/java/it/frafol/cleanping/bukkit/commands/utils/TabComplete.java
@@ -4,6 +4,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
+import org.bukkit.metadata.MetadataValue;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
@@ -18,8 +19,18 @@ public class TabComplete implements TabCompleter {
         }
 
         return sender.getServer().getOnlinePlayers().stream()
-                .filter(player -> player.getName().toLowerCase().startsWith(args[0].toLowerCase()))
+                .filter(player ->
+                        !isVanished(player) && player.getName().toLowerCase().startsWith(args[0].toLowerCase()))
                 .map(Player::getName)
                 .collect(Collectors.toList());
+    }
+
+    private boolean isVanished(Player player) {
+        for (MetadataValue meta : player.getMetadata("vanished")) {
+            if (meta.asBoolean()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/it/frafol/cleanping/bukkit/commands/utils/TabComplete.java
+++ b/src/main/java/it/frafol/cleanping/bukkit/commands/utils/TabComplete.java
@@ -1,29 +1,25 @@
 package it.frafol.cleanping.bukkit.commands.utils;
 
-import it.frafol.cleanping.bukkit.CleanPing;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class TabComplete implements TabCompleter {
 
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, String[] args) {
-
-        final List<String> list = new ArrayList<>();
-
-        if (command.getName().equalsIgnoreCase("ping")
-                || command.getName().equalsIgnoreCase("cleanping")) {
-
-            for (Player players : CleanPing.getInstance().getServer().getOnlinePlayers()) {
-                list.add(players.getName());
-            }
-
+        if (args.length != 1) {
+            return Collections.emptyList();
         }
-        return list;
+
+        return sender.getServer().getOnlinePlayers().stream()
+                .filter(player -> player.getName().toLowerCase().startsWith(args[0].toLowerCase()))
+                .map(Player::getName)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
- Removes old TabExecutor which was unused/overridden anyway (since it came after the legacy if checks)
- Now properly filters players by name
- Now checks for vanish (method used is supported by all competent vanish plugins)

You could also return `null` to have vanilla name completion, but there's an option in Paper to disable name completion on null return so this is the safer option.